### PR TITLE
Linux with Steamworks working

### DIFF
--- a/code/steamshim/launcher/make.sh
+++ b/code/steamshim/launcher/make.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export STEAMWORKSDIR=/path/to/steamworks_sdk_151/
+export RELEASE=0
+
+g++ -o launcher -Wall -O0 -ggdb3 -DRELEASE=$RELEASE steamshim_parent.cpp -I ${STEAMWORKSDIR}/sdk/public ${STEAMWORKSDIR}/sdk/redistributable_bin/linux64/libsteam_api.so

--- a/code/steamshim/launcher/steamshim_parent.cpp
+++ b/code/steamshim/launcher/steamshim_parent.cpp
@@ -1,4 +1,8 @@
+#ifdef WIN32
 #define GAME_LAUNCH_NAME "./RealRTCW.x64.exe"
+#else
+#define GAME_LAUNCH_NAME "./RealRTCW.x86_64"
+#endif
 #ifndef GAME_LAUNCH_NAME
 #error Please define your game exe name.
 #endif
@@ -38,8 +42,10 @@ static const uint32_t steam_app_id = 1379630u;
 static inline void dbgpipe(const char *fmt, ...) {}
 #endif
 
+#ifdef WIN32
 // maximum mumber of lines the output console should have
 static const WORD MAX_CONSOLE_LINES = 500;
+#endif
 
 /* platform-specific mainline calls this. */
 static int mainline(void);
@@ -694,6 +700,8 @@ static bool processCommand(const uint8 *buf, unsigned int buflen, PipeType fd)
                     writeGetStatF(fd, name, 0.0f, false);
             } // if
             break;
+            
+#ifdef RELEASE
         case SHIMCMD_RESTARTAPP:
             if (buflen == 5)
             {
@@ -703,6 +711,7 @@ static bool processCommand(const uint8 *buf, unsigned int buflen, PipeType fd)
                 writeRestartApp(fd, result);
             }
             break;
+#endif
 
         case SHIMCMD_SETRICHPRESENCE:
             if (buflen > 4)
@@ -781,10 +790,12 @@ static bool setEnvironmentVars(PipeType pipeChildRead, PipeType pipeChildWrite)
 
 static bool initSteamworks(PipeType fd)
 {
+#ifdef RELEASE
     if (SteamAPI_RestartAppIfNecessary(steam_app_id))
     {
         exit(0);
     }
+#endif
 
     // this can fail for many reasons:
     //  - you forgot a steam_appid.txt in the current working directory.

--- a/code/steamshim/steamshim_child.h
+++ b/code/steamshim/steamshim_child.h
@@ -1,6 +1,8 @@
 #ifndef _INCL_STEAMSHIM_CHILD_H_
 #define _INCL_STEAMSHIM_CHILD_H_
 
+#include <stdarg.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
A couple of fixes to make it compileable on Linux with Steam API integrated. Also "ported" steamshim launcher.

I didn't extensively test it, but it launches, starts game, loads saves, Steam sees me playing the game, Rich Presence is updated.
Currently it doesn't work absolutely well because I getting signal 11 similar to recent reports.

A things to note:

* I added `#include <stdarg.h>` to make va_args working, else it throws error. MSVC I guess is more forgivable for such quirks...
* For now I provided a simple shell script to compile launcher. It doesn't have build integration with makefile.
* I added `RELEASE` definition to easily disable `SteamAPI_RestartAppIfNecessary`. It's suggested that you set `RELEASE=1` in make.sh when you build for final release.
* You also need to edit `STEAMWORKSDIR` to point to where steamworks is located, to root folder where just sdk/ folder with everything.
* Linux build expects content in `main/` folder, not `Main/`. Case sensitivity, meh. More elegant solution would be nice.
* Doesn't load RTCW content located separately in Steam library. You need to manually copy everything. Any ideas of where to start figuring out?..
* No workshop addons detection as well.
* The game itself is built from Makefile. I used these settings I added into Makefile.local:
```makefile
ARCH=x86_64
STEAM=1
BUILD_GAME_SO=1
BUILD_CLIENT=1
BUILD_RENDERER_REND2=1
```
* You need to place linux64 libsteam_api.so near to game executable. To launch the game: `LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH ./launcher`