### PR TITLE
Update plist to add game mode and support high resolution displays

### DIFF
--- a/make-macosx-app.sh
+++ b/make-macosx-app.sh
@@ -351,6 +351,8 @@ PLIST="${PLIST}
     <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.games</string>
 </dict>
 </plist>
 "

--- a/make-macosx-app.sh
+++ b/make-macosx-app.sh
@@ -350,7 +350,7 @@ PLIST="${PLIST}
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>
-    <false/>
+    <true/>
 </dict>
 </plist>
 "


### PR DESCRIPTION
Adding game category to the app should allow the OS to activate game mode when in fullscreen.

Also stating support for high resolution displays will allow the dialogs to display clearly. 

Before: 
<img width="261" alt="Screenshot 2023-12-03 at 15 24 41" src="https://github.com/wolfetplayer/RealRTCW/assets/50119606/5ad766a0-6d4b-44a4-8b32-7f34460f6897">

After: 
<img width="258" alt="Screenshot 2023-12-03 at 15 22 22" src="https://github.com/wolfetplayer/RealRTCW/assets/50119606/54a4cec4-dfde-40d0-8f34-785339bf6f8c">
