### PR TITLE
Fix incorrect aspect ratio 16:9 in intro video

### DIFF
--- a/code/client/cl_console.c
+++ b/code/client/cl_console.c
@@ -654,6 +654,7 @@ void Con_DrawSolidConsole( float frac ) {
 	int lines;
 	int currentColor;
 	vec4_t color;
+	float	conLeft, conWidth;	// Patch added
 
 	lines = cls.glconfig.vidHeight * frac;
 	if ( lines <= 0 ) {
@@ -664,9 +665,14 @@ void Con_DrawSolidConsole( float frac ) {
 		lines = cls.glconfig.vidHeight;
 	}
 
+	// Patch added
+	conLeft = 0;
+	conWidth = SCREEN_WIDTH;
+	SCR_AdjustFrom640 (&conLeft, NULL, &conWidth, NULL, ALIGN_STRETCH);
+	// end Patch
 	// on wide screens, we will center the text
 	con.xadjust = 0;
-	SCR_AdjustFrom640( &con.xadjust, NULL, NULL, NULL );
+	SCR_AdjustFrom640 (&con.xadjust, NULL, NULL, NULL, ALIGN_STRETCH);
 
 	// draw the background
 	y = frac * SCREEN_HEIGHT;

--- a/code/client/cl_scrn.c
+++ b/code/client/cl_scrn.c
@@ -38,6 +38,12 @@ cvar_t      *cl_graphheight;
 cvar_t      *cl_graphscale;
 cvar_t      *cl_graphshift;
 
+// Patch added
+cvar_t		*scr_surroundlayout;	// whether to keep HUD/menu elements on center screen in triple-wide video modes
+cvar_t		*scr_surroundleft;		// left placement of HUD/menu elements on center screen in triple-wide video modes
+cvar_t		*scr_surroundright;		// right placement of HUD/menu elements on center screen in triple-wide video modes
+// end Patch
+
 /*
 ================
 SCR_DrawNamedPic
@@ -51,7 +57,7 @@ void SCR_DrawNamedPic( float x, float y, float width, float height, const char *
 	assert( width != 0 );
 
 	hShader = re.RegisterShader( picname );
-	SCR_AdjustFrom640( &x, &y, &width, &height );
+	SCR_AdjustFrom640( &x, &y, &width, &height, ALIGN_STRETCH );
 	re.DrawStretchPic( x, y, width, height, 0, 0, 1, 1, hShader );
 }
 
@@ -63,9 +69,11 @@ SCR_AdjustFrom640
 Adjusted for resolution and screen aspect ratio
 ================
 */
-void SCR_AdjustFrom640( float *x, float *y, float *w, float *h ) {
-	float xscale;
-	float yscale;
+void SCR_AdjustFrom640( float *x, float *y, float *w, float *h, scralign_t align ) {
+	float	screenAspect;
+	float	xscale, lb_xscale, yscale, minscale, vertscale;	// Patch added
+	float	tmp_x, tmp_y, tmp_w, tmp_h, tmp_left, tmp_right;	// Patch added
+	float	xleft, xright;
 
 #if 0
 	// adjust for wide screens
@@ -75,9 +83,269 @@ void SCR_AdjustFrom640( float *x, float *y, float *w, float *h ) {
 #endif
 
 	// scale for screen sizes
-	xscale = cls.glconfig.vidWidth / 640.0;
-	yscale = cls.glconfig.vidHeight / 480.0;
-	if ( x ) {
+//	xscale = cls.glconfig.vidWidth / 640.0;
+//	yscale = cls.glconfig.vidHeight / 480.0;
+//	minscale = min (xscale, yscale);
+	screenAspect = (float)cls.glconfig.vidWidth / (float)cls.glconfig.vidHeight;	// Patch added
+
+	// for eyefinity/surround setups, keep everything on the center monitor
+	if (scr_surroundlayout && scr_surroundlayout->integer && screenAspect >= 3.6f)
+	{
+		if (scr_surroundleft && scr_surroundleft->value > 0.0f && scr_surroundleft->value < 1.0f)
+			xleft = (float)cls.glconfig.vidWidth * scr_surroundleft->value;
+		else
+			xleft = (float)cls.glconfig.vidWidth / 3.0f;
+		if (scr_surroundright && scr_surroundright->value > 0.0f && scr_surroundright->value < 1.0f)
+			xright = (float)cls.glconfig.vidWidth * scr_surroundright->value;
+		else
+			xright = (float)cls.glconfig.vidWidth * (2.0f / 3.0f);
+		xscale = (xright - xleft) / SCREEN_WIDTH;
+	}
+	else {
+		xleft = 0.0f;
+		xright = (float)cls.glconfig.vidWidth;
+		xscale = (float)cls.glconfig.vidWidth / SCREEN_WIDTH;
+	}
+
+	lb_xscale = (float)cls.glconfig.vidWidth / SCREEN_WIDTH;
+	yscale = (float)cls.glconfig.vidHeight / SCREEN_HEIGHT;
+	minscale = min(xscale, yscale);
+
+	// hack for 5:4 modes
+	if ( !(xscale > yscale) && align != ALIGN_LETTERBOX)
+		align = ALIGN_STRETCH;
+
+	// Patch added anamorphic code
+	switch (align)
+	{
+	case ALIGN_CENTER:
+		if (x) {
+		tmp_x = *x;
+			*x = (tmp_x - (0.5 * SCREEN_WIDTH)) * minscale + (0.5 * cls.glconfig.vidWidth);
+		}
+		if (y) {
+			tmp_y = *y;
+			*y = (tmp_y - (0.5 * SCREEN_HEIGHT)) * minscale + (0.5 * cls.glconfig.vidHeight);
+		}
+		if (w) 
+			*w *= minscale;
+		if (h)
+			*h *= minscale;
+		break;
+	case ALIGN_LETTERBOX:
+		// special case: video mode (eyefinity?) is wider than object
+		if ( w != NULL && h != NULL && ((float)cls.glconfig.vidWidth / (float)cls.glconfig.vidHeight > *w / *h) ) {
+			tmp_h = *h;
+			vertscale = cls.glconfig.vidHeight / tmp_h;
+			if (x != NULL && w != NULL) {
+				tmp_x = *x;
+				tmp_w = *w;
+				*x = tmp_x * lb_xscale - (0.5 * (tmp_w * vertscale - tmp_w * lb_xscale));
+			}
+			if (y)
+				*y = 0;
+			if (w) 
+				*w *= vertscale;
+			if (h)
+				*h *= vertscale;
+		}
+		else {
+			if (x)
+				*x *= xscale;
+			if (y != NULL && h != NULL)  {
+				tmp_y = *y;
+				tmp_h = *h;
+				*y = tmp_y * yscale - (0.5 * (tmp_h * xscale - tmp_h * yscale));
+			}
+			if (w) 
+				*w *= xscale;
+			if (h)
+				*h *= xscale;
+		}
+		break;
+	case ALIGN_TOP:
+		if (w) 
+			*w *= minscale;
+		if (h)
+			*h *= minscale;
+		if (x) {
+			tmp_x = *x;
+			*x = (tmp_x - (0.5 * SCREEN_WIDTH)) * minscale + (0.5 * cls.glconfig.vidWidth);
+		}
+		if (y)
+			*y *= minscale;
+		break;
+	case ALIGN_BOTTOM:
+		if (w) 
+			*w *= minscale;
+		if (h)
+			*h *= minscale;
+		if (x) {
+			tmp_x = *x;
+			*x = (tmp_x - (0.5 * SCREEN_WIDTH)) * minscale + (0.5 * cls.glconfig.vidWidth);
+		}
+		if (y) {
+			tmp_y = *y;
+			*y = (tmp_y - SCREEN_HEIGHT) * minscale + cls.glconfig.vidHeight;
+		}
+		break;
+	case ALIGN_RIGHT:
+		if (w) 
+			*w *= minscale;
+		if (h)
+			*h *= minscale;
+		if (x) {
+			tmp_x = *x;
+			*x = (tmp_x - SCREEN_WIDTH) * minscale + xright;
+		}
+		if (y) {
+			tmp_y = *y;
+			*y = (tmp_y - (0.5 * SCREEN_HEIGHT)) * minscale + (0.5 * cls.glconfig.vidHeight);
+		}
+		break;
+	case ALIGN_LEFT:
+		if (w) 
+			*w *= minscale;
+		if (h)
+			*h *= minscale;
+		if (x)
+			*x *= minscale + xleft;
+		if (y) {
+			tmp_y = *y;
+			*y = (tmp_y - (0.5 * SCREEN_HEIGHT)) * minscale + (0.5 * cls.glconfig.vidHeight);
+		}
+		break;
+	case ALIGN_TOPRIGHT:
+		if (w) 
+			*w *= minscale;
+		if (h)
+			*h *= minscale;
+		if (x) {
+			tmp_x = *x;
+			*x = (tmp_x - SCREEN_WIDTH) * minscale + xright;
+		}
+		if (y)
+			*y *= minscale;
+		break;
+	case ALIGN_TOPLEFT:
+		if (w) 
+			*w *= minscale;
+		if (h)
+			*h *= minscale;
+		if (x) {
+			tmp_x = *x;
+			*x = tmp_x * minscale + xleft;
+		}
+		if (y)
+			*y *= minscale;
+		break;
+	case ALIGN_BOTTOMRIGHT:
+		if (w) 
+			*w *= minscale;
+		if (h)
+			*h *= minscale;
+		if (x) {
+			tmp_x = *x;
+			*x = (tmp_x - SCREEN_WIDTH) * minscale + xright;
+		}
+		if (y) {
+			tmp_y = *y;
+			*y = (tmp_y - SCREEN_HEIGHT) * minscale + cls.glconfig.vidHeight;
+		}
+		break;
+	case ALIGN_BOTTOMLEFT:
+		if (w) 
+			*w *= minscale;
+		if (h)
+			*h *= minscale;
+		if (x) {
+			tmp_x = *x;
+			*x = tmp_x * minscale + xleft;
+		}
+		if (y) {
+			tmp_y = *y;
+			*y = (tmp_y - SCREEN_HEIGHT) * minscale + cls.glconfig.vidHeight;
+		}
+		break;
+	case ALIGN_TOP_STRETCH:
+		if (w) 
+			*w *= xscale;
+		if (h)
+			*h *= minscale;
+		if (x) {
+			tmp_x = *x;
+			*x = tmp_x * xscale + xleft;
+		}
+		if (y)
+			*y *= minscale;
+		break;
+	case ALIGN_BOTTOM_STRETCH:
+		if (w) 
+			*w *= xscale;
+		if (h)
+			*h *= minscale;
+		if (x) {
+			tmp_x = *x;
+			*x = tmp_x * xscale + xleft;
+		}
+		if (y) {
+			tmp_y = *y;
+			*y = (tmp_y - SCREEN_HEIGHT) * minscale + cls.glconfig.vidHeight;
+		}
+		break;
+	case ALIGN_STRETCH_ALL:
+		if (x)
+			*x *= lb_xscale;
+		if (y) 
+			*y *= yscale;
+		if (w) 
+			*w *= lb_xscale;
+		if (h)
+			*h *= yscale;
+		break;
+	case ALIGN_STRETCH_LEFT_CENTER:
+		if (x && w) {
+			tmp_x = *x;
+			tmp_w = *w;
+			tmp_left = tmp_x * xscale + xleft;
+			tmp_right = (tmp_x + tmp_w - (0.5*SCREEN_WIDTH)) * minscale + (0.5*(cls.glconfig.vidWidth));
+			*x = tmp_left;
+			*w = tmp_right - tmp_left;
+		}
+		if (y) 
+			*y *= minscale;
+		if (h)
+			*h *= minscale;
+		break;
+	case ALIGN_STRETCH_RIGHT_CENTER:
+		if (x && w) {
+			tmp_x = *x;
+			tmp_w = *w;
+			tmp_left = (tmp_x - (0.5*SCREEN_WIDTH)) * minscale + (0.5*(cls.glconfig.vidWidth));
+			tmp_right = (tmp_x + tmp_w - SCREEN_WIDTH) * xscale + xright;
+			*x = tmp_left;
+			*w = tmp_right - tmp_left;
+		}
+		if (y) 
+			*y *= minscale;
+		if (h)
+			*h *= minscale;
+		break;
+	case ALIGN_STRETCH:
+	default:
+		if (x) {
+			tmp_x = *x;
+			*x = tmp_x * xscale + xleft;
+		}
+		if (y) 
+			*y *= yscale;
+		if (w) 
+			*w *= xscale;
+		if (h)
+			*h *= yscale;
+		break;
+	}
+/*	if ( x ) {
 		*x *= xscale;
 	}
 	if ( y ) {
@@ -88,7 +356,7 @@ void SCR_AdjustFrom640( float *x, float *y, float *w, float *h ) {
 	}
 	if ( h ) {
 		*h *= yscale;
-	}
+	}*/
 }
 
 /*
@@ -101,7 +369,7 @@ Coordinates are 640*480 virtual values
 void SCR_FillRect( float x, float y, float width, float height, const float *color ) {
 	re.SetColor( color );
 
-	SCR_AdjustFrom640( &x, &y, &width, &height );
+	SCR_AdjustFrom640( &x, &y, &width, &height, ALIGN_STRETCH );
 	re.DrawStretchPic( x, y, width, height, 0, 0, 0, 0, cls.whiteShader );
 
 	re.SetColor( NULL );
@@ -116,7 +384,7 @@ Coordinates are 640*480 virtual values
 =================
 */
 void SCR_DrawPic( float x, float y, float width, float height, qhandle_t hShader ) {
-	SCR_AdjustFrom640( &x, &y, &width, &height );
+	SCR_AdjustFrom640( &x, &y, &width, &height, ALIGN_STRETCH );
 	re.DrawStretchPic( x, y, width, height, 0, 0, 1, 1, hShader );
 }
 
@@ -145,7 +413,7 @@ static void SCR_DrawChar( int x, int y, float size, int ch ) {
 	ay = y;
 	aw = size;
 	ah = size;
-	SCR_AdjustFrom640( &ax, &ay, &aw, &ah );
+	SCR_AdjustFrom640( &ax, &ay, &aw, &ah, ALIGN_STRETCH );
 
 	row = ch >> 4;
 	col = ch & 15;

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -653,7 +653,7 @@ void	SCR_DebugGraph (float value);
 
 int     SCR_GetBigStringWidth( const char *str );   // returns in virtual 640x480 coordinates
 
-void    SCR_AdjustFrom640( float *x, float *y, float *w, float *h );
+void    SCR_AdjustFrom640( float *x, float *y, float *w, float *h, scralign_t align );	// Patch changed
 void    SCR_FillRect( float x, float y, float width, float height,
 					  const float *color );
 void    SCR_DrawPic( float x, float y, float width, float height, qhandle_t hShader );

--- a/code/renderer/tr_types.h
+++ b/code/renderer/tr_types.h
@@ -77,6 +77,27 @@ If you have questions concerning this license or the applicable additional terms
 #define RDF_DRAWINGSKY      ( 1 << 5 )
 #define RDF_SNOOPERVIEW     ( 1 << 6 )  //----(SA)	added
 
+// Patch screen item alignment types
+typedef enum
+{
+	ALIGN_UNSET = 0,
+	ALIGN_STRETCH,
+	ALIGN_STRETCH_LEFT_CENTER,
+	ALIGN_STRETCH_RIGHT_CENTER,
+	ALIGN_STRETCH_ALL,
+	ALIGN_CENTER,
+	ALIGN_LETTERBOX,
+	ALIGN_TOP,
+	ALIGN_BOTTOM,
+	ALIGN_RIGHT,
+	ALIGN_LEFT,
+	ALIGN_TOPRIGHT,
+	ALIGN_TOPLEFT,
+	ALIGN_BOTTOMRIGHT,
+	ALIGN_BOTTOMLEFT,
+	ALIGN_TOP_STRETCH,
+	ALIGN_BOTTOM_STRETCH,
+} scralign_t;
 
 typedef struct {
 	vec3_t xyz;


### PR DESCRIPTION
This patch fixes the incorrect 16:9 aspect ratio in the intro video. Tested in 4:3 (1920x1440), 16:9 (2560x1440), 21:9 (2560x1080) aspect ratio resolutions. The intro video aspect is now correct as per RTCW patch v1.42d.