### PR TITLE
Adding zoom sensitivity cvars

### DIFF
--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1779,6 +1779,8 @@ extern vmCvar_t cg_zoomDefaultBinoc;
 extern vmCvar_t cg_zoomDefaultSniper;
 extern vmCvar_t cg_zoomDefaultFG;
 extern vmCvar_t cg_zoomDefaultSnooper;
+extern vmCvar_t cg_zoomSensitivity;
+extern vmCvar_t cg_zoomSensitivityFovScaled;
 extern vmCvar_t cg_zoomStepBinoc;
 extern vmCvar_t cg_zoomStepSniper;
 extern vmCvar_t cg_zoomStepSnooper;

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -184,6 +184,8 @@ vmCvar_t cg_zoomStepBinoc;
 vmCvar_t cg_zoomStepSniper;
 vmCvar_t cg_zoomStepSnooper;
 vmCvar_t cg_zoomStepFG;         //----(SA)	added
+vmCvar_t cg_zoomSensitivity;
+vmCvar_t cg_zoomSensitivityFovScaled;
 vmCvar_t cg_zoomDefaultBinoc;
 vmCvar_t cg_zoomDefaultSniper;
 vmCvar_t cg_zoomDefaultSnooper;
@@ -328,6 +330,8 @@ cvarTable_t cvarTable[] = {
 	{ &cg_zoomDefaultSniper, "cg_zoomDefaultSniper", "15", CVAR_ARCHIVE },
 	{ &cg_zoomDefaultSnooper, "cg_zoomDefaultSnooper", "40", CVAR_ARCHIVE },
 	{ &cg_zoomDefaultFG, "cg_zoomDefaultFG", "55", CVAR_ARCHIVE },                //----(SA)	added
+	{ &cg_zoomSensitivityFovScaled, "cg_zoomSensitivityFovScaled", "1", CVAR_ARCHIVE },
+	{ &cg_zoomSensitivity, "cg_zoomSensitivity", "1", CVAR_ARCHIVE },
 	{ &cg_zoomStepBinoc, "cg_zoomStepBinoc", "3", CVAR_ARCHIVE },
 	{ &cg_zoomStepSniper, "cg_zoomStepSniper", "2", CVAR_ARCHIVE },
 	{ &cg_zoomStepSnooper, "cg_zoomStepSnooper", "5", CVAR_ARCHIVE },

--- a/code/cgame/cg_view.c
+++ b/code/cgame/cg_view.c
@@ -932,24 +932,24 @@ static int CG_CalcFov( void ) {
 	cg.refdef.fov_x = fov_x;
 	cg.refdef.fov_y = fov_y;
 
-	if ( !cg.zoomedBinoc ) {
-		// NERVE - SMF - fix for zoomed in/out movement bug
-		if ( cg.zoomval ) {
-			if ( cg.snap->ps.weapon == WP_SNOOPERSCOPE ) {
-				cg.zoomSensitivity = 0.3f * ( cg.zoomval / 90.f );  // NERVE - SMF - changed to get less sensitive as you zoom in;
-			}
-//				cg.zoomSensitivity = 0.2;
-			else {
-				cg.zoomSensitivity = 0.6 * ( cg.zoomval / 90.f );   // NERVE - SMF - changed to get less sensitive as you zoom in
-			}
-//				cg.zoomSensitivity = 0.1;
-		} else {
-			cg.zoomSensitivity = 1;
+	// RealRTCW - sensitivity multiplier and scaling by fov
+	float zoomSensFovScale = 1;
+	if( cg_zoomSensitivityFovScaled.integer ) {
+		if( cg.zoomedBinoc ) {
+			zoomSensFovScale = cg.refdef.fov_y / 75.0;
 		}
-		// -NERVE - SMF
-	} else {
-		cg.zoomSensitivity = cg.refdef.fov_y / 75.0;
+		else if ( cg.zoomval ) {
+			if ( cg.snap->ps.weapon == WP_SNOOPERSCOPE ) {
+				zoomSensFovScale = 0.3f * ( cg.zoomval / 90.f );
+			}
+			else {
+				zoomSensFovScale = 0.6 * ( cg.zoomval / 90.f );
+			}
+		}
 	}
+	float zoomSensMultiplier = ( cg.zoomedBinoc || cg.zoomval ) ? cg_zoomSensitivity.value : 1;
+	
+	cg.zoomSensitivity = zoomSensFovScale * zoomSensMultiplier;
 
 	return inwater;
 }

--- a/code/client/cl_input.c
+++ b/code/client/cl_input.c
@@ -381,16 +381,17 @@ void CL_KeyMove( usercmd_t *cmd ) {
 	side += movespeed * CL_KeyState( &kb[KB_MOVERIGHT] );
 	side -= movespeed * CL_KeyState( &kb[KB_MOVELEFT] );
 
+// Why would anyone disable strafing when holding down use key?
 //----(SA)	added
-	if ( cmd->buttons & BUTTON_ACTIVATE ) {
-		if ( side > 0 ) {
-			cmd->wbuttons |= WBUTTON_LEANRIGHT;
-		} else if ( side < 0 ) {
-			cmd->wbuttons |= WBUTTON_LEANLEFT;
-		}
+	// if ( cmd->buttons & BUTTON_ACTIVATE ) {
+	// 	if ( side > 0 ) {
+	// 		cmd->wbuttons |= WBUTTON_LEANRIGHT;
+	// 	} else if ( side < 0 ) {
+	// 		cmd->wbuttons |= WBUTTON_LEANLEFT;
+	// 	}
 
-		side = 0;   // disallow the strafe when holding 'activate'
-	}
+	// 	side = 0;   // disallow the strafe when holding 'activate'
+	// }
 //----(SA)	end
 
 	up += movespeed * CL_KeyState( &kb[KB_UP] );


### PR DESCRIPTION
Adding two cvars to configure zoom sensitivity.  At default settings(both at 1) zoom sensitivity stays unchanged.

Cvar "cg_zoomSensitivity" is zoom sensitivity multiplier, e.g. value 0.8 is 80% zoom sensitivity.

Cvar "cg_zoomSensitivityFovScaled" disables zoom sensitivity FOV scaling when set to 0, e.g. when set to 0 zoom sensitivity is same as hip-fire sensitivity if "cg_zoomSensitivity" is set to 1.

Lastly there is small QoL improvement, allowing strafing while holding down use key.