### PR TITLE
Linux compilation fix for version 5.1

### DIFF
--- a/code/cgame/cg_weapons.c
+++ b/code/cgame/cg_weapons.c
@@ -1700,11 +1700,11 @@ static qboolean CG_RW_ParseClient( int handle, weaponInfo_t *weaponInfo, int wea
 				return CG_RW_ParseError( handle, "expected missileDlight value" );
 			}
 		} else if ( !Q_stricmp( token.string, "wiTrailTime" ) ) {
-			if ( !PC_Int_Parse( handle, &weaponInfo->wiTrailTime ) ) {
+			if ( !PC_Int_Parse( handle, (int *)&weaponInfo->wiTrailTime ) ) {
 				return CG_RW_ParseError( handle, "expected wiTrailTime value" );
 			}
 		} else if ( !Q_stricmp( token.string, "trailRadius" ) ) {
-			if ( !PC_Int_Parse( handle, &weaponInfo->trailRadius ) ) {
+			if ( !PC_Int_Parse( handle, (int *)&weaponInfo->trailRadius ) ) {
 				return CG_RW_ParseError( handle, "expected trailRadius value" );
 			}
 		} else if ( !Q_stricmp( token.string, "missileDlightColor" ) ) {

--- a/code/game/ai_cast_funcs.c
+++ b/code/game/ai_cast_funcs.c
@@ -5880,23 +5880,23 @@ qboolean BG_ParseSurvivalTable( int handle )
 			}
 		// string
 		} else if ( !Q_stricmp( token.string, "announcerSound" ) ) {
-			if ( !PC_String_ParseNoAlloc( handle, &svParams.announcerSound[0], MAX_QPATH ) ) {
+			if ( !PC_String_ParseNoAlloc( handle, (char *)&svParams.announcerSound[0], MAX_QPATH ) ) {
 				PC_SourceError( handle, "expected announcerSound value" );
 				return qfalse;
 			}
 		} else if ( Q_stristr( token.string, "announcerSound" ) == token.string ) {
 			sscanf( token.string, "announcerSound%d", &i );
 
-			if ( !PC_String_ParseNoAlloc( handle, &soundPath, MAX_QPATH ) ) {
+			if ( !PC_String_ParseNoAlloc( handle, (char *)&soundPath, MAX_QPATH ) ) {
 				PC_SourceError( handle, "expected announcerSound value" );
 				return qfalse;
 			}
 
 			if ( i - 1 >= ANNOUNCE_SOUNDS_COUNT ) {
-				sprintf_s(msg, 64, "announcerSound[%d] out of range. Increase ANNOUNCE_SOUNDS_COUNT", i - 1 );
+				sprintf(msg, "announcerSound[%d] out of range. Increase ANNOUNCE_SOUNDS_COUNT", i - 1 );
 				PC_SourceError( handle, msg );
 			} else {
-				strcpy_s( svParams.announcerSound[i - 1], MAX_QPATH, soundPath );
+				strcpy( svParams.announcerSound[i - 1], soundPath );
 			}
 		} else {
 			PC_SourceError( handle, "unknown token '%s'", token.string );


### PR DESCRIPTION
Functions `sprintf_s` and `strcpy_s` aren't part of standard C library and are missing on Linux. Functions `sprintf` and `strcpy` can be used instead.

Also 4 explicit type conversions of pointers are included, since it would not compile without them.