### PR TITLE
Fix crash when loaded models' non-existent LOD levels / Separate pistols' clips count display

### DIFF
--- a/code/cgame/cg_newdraw.c
+++ b/code/cgame/cg_newdraw.c
@@ -506,6 +506,7 @@ static void CG_DrawPlayerAmmoValue( rectDef_t *rect, int font, float scale, vec4
 	playerState_t   *ps;
 	int weap;
 	qboolean special = qfalse;
+	weapon_t specialWeap = WP_NONE;
 
 	cent = &cg_entities[cg.snap->ps.clientNum];
 	ps = &cg.snap->ps;
@@ -532,8 +533,10 @@ static void CG_DrawPlayerAmmoValue( rectDef_t *rect, int font, float scale, vec4
 		return;
 
 	case WP_AKIMBO:
+		specialWeap = WP_COLT;
+		break;
 	case WP_DUAL_TT33:
-		special = qtrue;
+		specialWeap = WP_TT33;
 		break;
 
 	case WP_GRENADE_LAUNCHER:
@@ -553,12 +556,14 @@ static void CG_DrawPlayerAmmoValue( rectDef_t *rect, int font, float scale, vec4
 		break;
 	}
 
+	if ( specialWeap > WP_NONE && specialWeap < WP_NUM_WEAPONS ) special = qtrue;
+
 	if ( type == 0 ) { // ammo
 		value = cg.snap->ps.ammo[BG_FindAmmoForWeapon( weap )];
 	} else {        // clip
 		value = ps->ammoclip[BG_FindClipForWeapon( weap )];
 		if ( special ) {
-			value2 = value;
+			value2 = ps->ammoclip[BG_FindClipForWeapon( specialWeap )];
 			if ( ammoTable[weap].weapAlts ) {
 				value = ps->ammoclip[ammoTable[weap].weapAlts];
 			}

--- a/code/game/bg_misc.c
+++ b/code/game/bg_misc.c
@@ -3788,7 +3788,7 @@ model="models/weapons2/sp5/sp5.md3"
 		WP_SILENCER,
 		WP_LUGER,
 		WP_SILENCER,
-		WP_LUGER,
+		WP_SILENCER,	// don't sync clips with luger since they are separated
 		"",                 
 		"",                  
 		{0,0,0,0,0,0}

--- a/code/renderer/tr_cmesh.c
+++ b/code/renderer/tr_cmesh.c
@@ -267,6 +267,51 @@ static int R_ComputeLOD( trRefEntity_t *ent ) {
 		lod = 0;
 	}
 
+	// prevent crash when loaded a LOD levels that may not actually exists
+	int lod_pre = lod;
+	switch (tr.currentModel->type) {
+		case MOD_MDC:
+			// mdc check
+			if (lod >= MD3_MAX_LODS || tr.currentModel->mdc[lod] == NULL) {
+				// find first available LOD to prevent NULL pointer
+				int foundLod = -1;
+				for (int i = 0; i < MD3_MAX_LODS; i++) {
+					if (tr.currentModel->mdc[i] != NULL) {
+						foundLod = i;
+						break;
+					}
+				}
+				lod = (foundLod >= 0) ? foundLod : 0;
+			}
+			break;
+		case MOD_MESH:
+			// md3 check
+			if (lod >= MD3_MAX_LODS || tr.currentModel->md3[lod] == NULL) {
+				// find first available LOD to prevent NULL pointer
+				int foundLod = -1;
+				for (int i = 0; i < MD3_MAX_LODS; i++) {
+					if (tr.currentModel->md3[i] != NULL) {
+						foundLod = i;
+						break;
+					}
+				}
+				lod = (foundLod >= 0) ? foundLod : 0;
+			}
+			break;
+		case MOD_MDR:
+		case MOD_MDS:
+		case MOD_IQM:
+		case MOD_BRUSH:
+		case MOD_BAD:
+		default:
+			break;
+	}
+
+	if (lod != lod_pre) {
+		ri.Printf( PRINT_DEVELOPER, "\"R_ComputeLOD:\" \"%s\" LOD index %d doesn't exist, change to %d\n", tr.currentModel->name, lod_pre, lod);
+	}
+	// end, C-ColinTH
+
 	return lod;
 }
 

--- a/code/renderer/tr_mesh.c
+++ b/code/renderer/tr_mesh.c
@@ -266,6 +266,51 @@ int R_ComputeLOD( trRefEntity_t *ent ) {
 		lod = 0;
 	}
 
+	// prevent crash when loaded a LOD levels that may not actually exists
+	int lod_pre = lod;
+	switch (tr.currentModel->type) {
+		case MOD_MDC:
+			// mdc check
+			if (lod >= MD3_MAX_LODS || tr.currentModel->mdc[lod] == NULL) {
+				// find first available LOD to prevent NULL pointer
+				int foundLod = -1;
+				for (int i = 0; i < MD3_MAX_LODS; i++) {
+					if (tr.currentModel->mdc[i] != NULL) {
+						foundLod = i;
+						break;
+					}
+				}
+				lod = (foundLod >= 0) ? foundLod : 0;
+			}
+			break;
+		case MOD_MESH:
+			// md3 check
+			if (lod >= MD3_MAX_LODS || tr.currentModel->md3[lod] == NULL) {
+				// find first available LOD to prevent NULL pointer
+				int foundLod = -1;
+				for (int i = 0; i < MD3_MAX_LODS; i++) {
+					if (tr.currentModel->md3[i] != NULL) {
+						foundLod = i;
+						break;
+					}
+				}
+				lod = (foundLod >= 0) ? foundLod : 0;
+			}
+			break;
+		case MOD_MDR:
+		case MOD_MDS:
+		case MOD_IQM:
+		case MOD_BRUSH:
+		case MOD_BAD:
+		default:
+			break;
+	}
+
+	if (lod != lod_pre) {
+		ri.Printf( PRINT_DEVELOPER, "\"R_ComputeLOD:\" \"%s\" LOD index %d doesn't exist, change to %d\n", tr.currentModel->name, lod_pre, lod);
+	}
+	// end, C-ColinTH
+
 	return lod;
 }
 


### PR DESCRIPTION
## [Fix crash when loaded models' non-existent LOD levels](https://github.com/wolfetplayer/RealRTCW/pull/144/commits/4e5d662c5710283423949a2de48aa01401730126)
Game crashes with SIGSEGV (signal 11) when requested models' LOD levels that weren't actually exist, particularly with both:
- Low/Medium geometric detail settings ("r_lodbias").
- Models with incomplete LOD sets.

This LOD safety validation for multiple model types should fix that.

A specific example:
In addons "victors" level "odb38", game will crash when player switched Geometric detail setting from High/Extra to Low/Medium. This problem due to renderer try to load non-existent LOD levels from model "models/mapobjects/tree/tree_m08.md3".

## [Separate pistols' clips count display](https://github.com/wolfetplayer/RealRTCW/pull/144/commits/6f5ec2b8fefb9e24704bfdc7d63207e1d2381dd9)
- LugerSilencer no longer synchronize the clips count with Luger.
- Dual pistols now show accurate clips count for each pistol.
