### PR TITLE
Potential signal 11 crash fix, caused by models with incomplete LOD levels

### DIFF
--- a/code/renderer/tr_cmesh.c
+++ b/code/renderer/tr_cmesh.c
@@ -267,6 +267,51 @@ static int R_ComputeLOD( trRefEntity_t *ent ) {
 		lod = 0;
 	}
 
+	// prevent crash when try to load model's LOD levels that may not actually exist
+	int lod_pre = lod;
+	switch (tr.currentModel->type) {
+		case MOD_MDC:
+			// mdc check
+			if (lod >= MD3_MAX_LODS || tr.currentModel->mdc[lod] == NULL) {
+				// find first available LOD to prevent NULL pointer
+				int foundLod = -1;
+				for (int i = 0; i < MD3_MAX_LODS; i++) {
+					if (tr.currentModel->mdc[i] != NULL) {
+						foundLod = i;
+						break;
+					}
+				}
+				lod = (foundLod >= 0) ? foundLod : 0;
+			}
+			break;
+		case MOD_MESH:
+			// md3 check
+			if (lod >= MD3_MAX_LODS || tr.currentModel->md3[lod] == NULL) {
+				// find first available LOD to prevent NULL pointer
+				int foundLod = -1;
+				for (int i = 0; i < MD3_MAX_LODS; i++) {
+					if (tr.currentModel->md3[i] != NULL) {
+						foundLod = i;
+						break;
+					}
+				}
+				lod = (foundLod >= 0) ? foundLod : 0;
+			}
+			break;
+		case MOD_MDR:
+		case MOD_MDS:
+		case MOD_IQM:
+		case MOD_BRUSH:
+		case MOD_BAD:
+		default:
+			break;
+	}
+
+	if (lod != lod_pre) {
+		ri.Printf( PRINT_DEVELOPER, "\"R_ComputeLOD:\" \"%s\" index %d for LOD doesn't exist, change to %d\n",
+			tr.currentModel->name, lod_pre, lod);
+	}
+
 	return lod;
 }
 

--- a/code/renderer/tr_mesh.c
+++ b/code/renderer/tr_mesh.c
@@ -266,6 +266,51 @@ int R_ComputeLOD( trRefEntity_t *ent ) {
 		lod = 0;
 	}
 
+	// prevent crash when try to load model's LOD levels that may not actually exist
+	int lod_pre = lod;
+	switch (tr.currentModel->type) {
+		case MOD_MDC:
+			// mdc check
+			if (lod >= MD3_MAX_LODS || tr.currentModel->mdc[lod] == NULL) {
+				// find first available LOD to prevent NULL pointer
+				int foundLod = -1;
+				for (int i = 0; i < MD3_MAX_LODS; i++) {
+					if (tr.currentModel->mdc[i] != NULL) {
+						foundLod = i;
+						break;
+					}
+				}
+				lod = (foundLod >= 0) ? foundLod : 0;
+			}
+			break;
+		case MOD_MESH:
+			// md3 check
+			if (lod >= MD3_MAX_LODS || tr.currentModel->md3[lod] == NULL) {
+				// find first available LOD to prevent NULL pointer
+				int foundLod = -1;
+				for (int i = 0; i < MD3_MAX_LODS; i++) {
+					if (tr.currentModel->md3[i] != NULL) {
+						foundLod = i;
+						break;
+					}
+				}
+				lod = (foundLod >= 0) ? foundLod : 0;
+			}
+			break;
+		case MOD_MDR:
+		case MOD_MDS:
+		case MOD_IQM:
+		case MOD_BRUSH:
+		case MOD_BAD:
+		default:
+			break;
+	}
+
+	if (lod != lod_pre) {
+		ri.Printf( PRINT_DEVELOPER, "\"R_ComputeLOD:\" \"%s\" index %d for LOD doesn't exist, change to %d\n",
+			tr.currentModel->name, lod_pre, lod);
+	}
+
 	return lod;
 }
 


### PR DESCRIPTION
Game crashes with SIGSEGV (signal 11) when loaded model's LOD levels that not actually exist, The conditions for this situation to occur are:
- Models with incomplete LOD levels.
- Low/Medium geometric detail settings (attach to "r_lodbias").

This LOD safety validation fix that.