### PR TITLE
Fix window restoration issue after called Sys_OpenURL

### DIFF
--- a/code/sys/sys_win32.c
+++ b/code/sys/sys_win32.c
@@ -982,7 +982,7 @@ void Sys_OpenURL( char *url, qboolean doexit ) {                // NERVE - SMF
 	wnd = GetForegroundWindow();
 
 	if ( wnd ) {
-		ShowWindow( wnd, SW_MAXIMIZE );
+		ShowWindow( wnd, SW_RESTORE );
 	}
 
 	if ( doexit ) {


### PR DESCRIPTION
On the Windows platform, when the game is running in window mode and the function Sys_SpenURL is called to open a web link, once the game window is minimized by the player, the window cannot be restored thereafter.

This fixed that.