### PR TITLE
MAX_DRAWIMAGES, MAX_SKINS doubled

### DIFF
--- a/code/renderer/tr_local.h
+++ b/code/renderer/tr_local.h
@@ -991,8 +991,8 @@ void        R_Modellist_f( void );
 //====================================================
 extern refimport_t ri;
 
-#define MAX_DRAWIMAGES          2048
-#define MAX_SKINS               1024
+#define MAX_DRAWIMAGES          4096	// was 2048
+#define MAX_SKINS               2048	// was 1024
 
 
 #define MAX_DRAWSURFS           0x10000


### PR DESCRIPTION
Prevent 'MAX_DRAWIMAGES hit' or 'MAX_SKINS hit' On big and heavy maps, they will cause the game to be shut down forcefully.

See `R_CreateImageExt`, `RE_RegisterSkin` in `tr_image.c`.