### PR TITLE
Fix some potential Memory Pool Out-of-Bounds Read issues

### DIFF
--- a/code/game/ai_cast_script.c
+++ b/code/game/ai_cast_script.c
@@ -749,7 +749,8 @@ void AICast_ScriptLoad( void ) {
 		}
 	}
 
-	level.scriptAI = G_Alloc( len );
+	level.scriptAI = G_Alloc( len + 1 );
+	memset( level.scriptAI, 0 , len + 1 );
 	trap_FS_Read( level.scriptAI, len, f );
 
 	trap_FS_FCloseFile( f );

--- a/code/game/g_bot.c
+++ b/code/game/g_bot.c
@@ -184,7 +184,7 @@ void G_LoadArenas( void ) {
         if ( *type ) { 
             if ( strstr( type, "sv_normal" ) && i < MAX_MAPS ) { 
 				char *map = Info_ValueForKey( g_arenaInfos[n], "map" );
-				level.maplist[i] = G_Alloc(strlen(map));
+				level.maplist[i] = G_Alloc( strlen(map) + 1 );
 				strcpy(level.maplist[i++], map);
             }   
         }   

--- a/code/game/g_script.c
+++ b/code/game/g_script.c
@@ -294,7 +294,8 @@ void G_Script_ScriptLoad( void ) {
 		return;
 	}
 
-	level.scriptEntity = G_Alloc( len );
+	level.scriptEntity = G_Alloc( len + 1 );
+	memset( level.scriptEntity, 0 , len + 1 );
 	trap_FS_Read( level.scriptEntity, len, f );
 
 	trap_FS_FCloseFile( f );

--- a/code/game/g_spawn.c
+++ b/code/game/g_spawn.c
@@ -1024,7 +1024,8 @@ qboolean G_LoadEntsFile( void ) {
 		}
 	}
 
-	level.extraEntsScript = G_Alloc( len );
+	level.extraEntsScript = G_Alloc( len + 1 );
+	memset( level.extraEntsScript, 0 , len + 1 );
 	trap_FS_Read( level.extraEntsScript, len, f );
 
 	trap_FS_FCloseFile( f );


### PR DESCRIPTION
https://github.com/wolfetplayer/RealRTCW/issues/165

When the length of the content in the `.ai .script .ents` file is exactly a multiple of 32, it may cause Memory Pool Out-of-Bounds Read issue.
This should fix it.