### PR TITLE
[EXPERIMENTAL] Utf8 file path supported for windows platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1262,6 +1262,11 @@ ifdef STEAM
   CLIENT_CFLAGS += -DSTEAM
 endif
 
+ifdef UTF8
+  CFLAGS += -DUTF8
+  CLIENT_CFLAGS += -DUTF8
+endif
+
 ifeq ($(USE_INTERNAL_ZLIB),1)
   ZLIB_CFLAGS = -DNO_GZIP -I$(ZDIR)
 else

--- a/code/zlib-1.2.11/ioapi.c
+++ b/code/zlib-1.2.11/ioapi.c
@@ -28,6 +28,16 @@
 
 #include "ioapi.h"
 
+#if defined(UTF8) && defined(_WIN32)
+extern FILE *Sys_FOpen(const char* utf8_path, const char* mode);
+
+#ifdef FOPEN_FUNC
+    #undef FOPEN_FUNC
+#endif
+
+#define FOPEN_FUNC(filename, mode) Sys_FOpen(filename, mode)
+#endif
+
 voidpf call_zopen64 (const zlib_filefunc64_32_def* pfilefunc,const void*filename,int mode)
 {
     if (pfilefunc->zfile_func64.zopen64_file != NULL)


### PR DESCRIPTION
Feature:
* Now even if the game path contains non ASCII characters, it should be able to be recognized normally.
* Even if the file name of game PK3 package and other data files contains non ASCII characters, they should still be able to load normally.

Note: Testing well on my two win10 system computers, but more samples may be needed for this.

Build: Using `UTF8` flag

for example:
`mingw32-make ARCH=x86_64 UTF8=1`