### PR TITLE
`dirlist` buffer increased

### DIFF
--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -3608,7 +3608,7 @@ UI_LoadMods
 */
 static void UI_LoadMods( void ) {
 	int numdirs;
-	char dirlist[2048];
+	char dirlist[8192];
 	char    *dirptr;
 	char  *descptr;
 	int i;


### PR DESCRIPTION
Fix some mods in the mods list are missing due to the short buffer being truncated.

When there are many mods folders in the player's game search directory, the parts that exceed the buffer will not be displayed in the mod list. So players could not find some mods they subscribed in the game menu.

This fixed that.