### PR TITLE
Support cinematic subtitle

### DIFF
--- a/code/client/cl_cin.c
+++ b/code/client/cl_cin.c
@@ -2854,7 +2854,7 @@ static void CIN_LoadCinematicSubtitle( int handle ) {
 	text = buffer;
 	token = COM_ParseExt(&text, qtrue);
 	if (token[0] != '{') {
-		Com_Printf("^1WARNING: expecting '{', found '%s' instead in cine subtitle file \"video/%s\"\n", token, name);
+		Com_Printf("^1WARNING: expecting '{', found '%s' instead in cine subtitle file \"%s\"\n", token, name);
 		return;
 	}
 
@@ -2864,7 +2864,7 @@ static void CIN_LoadCinematicSubtitle( int handle ) {
 	while ( cinTable[handle].subtitleCount < MAX_SUBTITLES) {
 		token = COM_ParseExt(&text, qtrue);
 		if (!token[0]) {
-			Com_Printf("^1WARNING: no concluding '}' in cine subtitle file \"video/%s\"\n", name);
+			Com_Printf("^1WARNING: no concluding '}' in cine subtitle file \"%s\"\n", name);
 			break;
 		}
 		// end of shader definition

--- a/code/client/cl_cin.c
+++ b/code/client/cl_cin.c
@@ -2797,7 +2797,8 @@ static int CIN_GetCurrentPlayingTime( int handle ) {
 ==================
 CIN_LoadCinematicSubtitle
 
-  startTime endTime text sizeScale x0, y0, width [x1 y1]
+syntax:
+  <startTime> <endTime> <text> <sizeScale> <x0> <y0> <width> [x1 y1]
   
     startTime endTime: millisecond
     sizeScale: font scale

--- a/code/client/cl_cin.c
+++ b/code/client/cl_cin.c
@@ -2828,6 +2828,9 @@ static void CIN_LoadCinematicSubtitle( int handle ) {
 	int len, i;
 	char *token;
 
+	// initial clear
+	memset( cinTable[handle].subtitles, 0, sizeof(cinTable[handle].subtitles) );
+
 	// cine subtitle filename
 	Q_strncpyz( name, cinTable[handle].fileName, sizeof(name) );
 	char *dot = strrchr( name, '.' );
@@ -2838,11 +2841,11 @@ static void CIN_LoadCinematicSubtitle( int handle ) {
 
 	// read file content
 	len = FS_FOpenFileByMode(name, &f, FS_READ);
-	if (len <= 0 && com_developer->integer) {
-		Com_Printf(S_COLOR_YELLOW "cine subtitle file \"%s\" not found or unreadable\n", name);
+	if (len <= 0) {
+		Com_DPrintf(S_COLOR_YELLOW "cine subtitle file \"%s\" not found or unreadable\n", name);
 		return;
 	}
-	if (len > MAX_BUFFER) {
+	if (len >= MAX_BUFFER) {
 		Com_Printf(S_COLOR_YELLOW "\"%s\" is too big, make it smaller (max = %i bytes)\n", name, MAX_BUFFER);
 	}
 
@@ -2857,8 +2860,6 @@ static void CIN_LoadCinematicSubtitle( int handle ) {
 		Com_Printf("^1WARNING: expecting '{', found '%s' instead in cine subtitle file \"%s\"\n", token, name);
 		return;
 	}
-
-	memset( cinTable[handle].subtitles, 0, sizeof(cinTable[handle].subtitles) );
 
 	i = 0;
 	while ( cinTable[handle].subtitleCount < MAX_SUBTITLES) {

--- a/code/client/cl_cin.c
+++ b/code/client/cl_cin.c
@@ -2964,7 +2964,8 @@ static void CIN_DrawCinematicSubtitle( int handle ) {
 			}
 
 			SCR_Text_AutoWrapped_Paint( x, y, subs[i].sizeScale, subs[i].lineText,
-										subs[i].width, color, TEXT_ALIGN_CENTER );
+										subs[i].width, color, TEXT_ALIGN_CENTER,
+										cls.subtitleCharSetShader );
 		}
 	}
 

--- a/code/client/cl_cin.c
+++ b/code/client/cl_cin.c
@@ -89,6 +89,24 @@ static long long FFMPEG_Seek( void *opaque, long long offset, int whence );
 static int FFMPEG_ReadFrame( qboolean onlyAudio );
 static int FFMPEG_DecodeVideo( );
 
+#define MAX_SUBTITLES       256
+#define MAX_SUBTITLE_CHARS  1024
+#define MAX_BUFFER          32000
+
+typedef struct {
+    int startTime, endTime;	// ms
+	char lineText[MAX_SUBTITLE_CHARS];
+	float sizeScale;
+    int x0, y0;
+	int width;	// max width per line
+	int x1, y1;
+} subtitle_t;
+
+extern cvar_t *cl_drawCineSubtitles;
+static int CIN_GetCurrentPlayingTime( int handle );
+static void CIN_LoadCinematicSubtitle( int handle );
+static void CIN_DrawCinematicSubtitle( int handle );
+
 /******************************************************************************
 *
 * Class:		trFMV
@@ -194,6 +212,10 @@ typedef struct {
 
 	int sar_num;
 	int sar_den;
+
+	// subtitle
+	int subtitleCount;
+	subtitle_t subtitles[MAX_SUBTITLES];
 } cin_cache;
 
 static cinematics_t cin;
@@ -2279,6 +2301,9 @@ int CIN_PlayCinematic( const char *arg, int x, int y, int w, int h, int systemBi
 		}
 	}
 
+	// load .sub cine subtitle file
+	CIN_LoadCinematicSubtitle( currentHandle );
+
 	CIN_SetExtents( currentHandle, x, y, w, h );
 	CIN_SetLooping( currentHandle, ( systemBits & CIN_loop ) != 0 );
 
@@ -2557,6 +2582,9 @@ h = cls.glconfig.vidHeight;
 	                   buf, handle, cinTable[handle].dirty );
 
 	cinTable[handle].dirty = qfalse;
+
+	// draw cine subtitles
+	CIN_DrawCinematicSubtitle( handle );
 }
 
 /*
@@ -2745,4 +2773,198 @@ void SCR_DrawLevelCinematic( void ) {
     if ( CL_levelCinHandle >= 0 && CL_levelCinHandle < MAX_VIDEO_HANDLES ) {
         CIN_DrawCinematic( CL_levelCinHandle );
     }
+}
+
+
+/*
+==================
+CIN_GetCurrentPlayingTime
+==================
+*/
+static int CIN_GetCurrentPlayingTime( int handle ) {
+	if ( handle < 0 || handle >= MAX_VIDEO_HANDLES ) {
+		return -1;
+	}
+
+	if ( cinTable[handle].roqFPS <= 0 ) {
+		return -1;
+	}
+
+	return (cinTable[handle].tfps * 1000) / cinTable[handle].roqFPS;
+}
+
+/*
+==================
+CIN_LoadCinematicSubtitle
+
+  startTime endTime text sizeScale x0, y0, width [x1 y1]
+  
+    startTime endTime: millisecond
+    sizeScale: font scale
+    x0, y0, width: set the rectangle size, position adjust from 640x480
+    x1 y1: the end position of the rectangle (Optional parameters, set these if subtitles need move)
+
+	-----------------------------
+	|                           |
+	| x0         x0 + width     |
+	|  \            \           |
+	|  *------------*           |  <- y0
+	|  |    text    |           |
+	|  |    text    |           |
+	|  |    ...     |           |
+	|                           |
+	-----------------------------
+==================
+*/
+static void CIN_LoadCinematicSubtitle( int handle ) {
+	if ( handle < 0 || handle >= MAX_VIDEO_HANDLES || cinTable[handle].status == FMV_EOF ) {
+		return;
+	}
+
+	char name[MAX_OSPATH];
+	char buffer[MAX_BUFFER];
+	char *text;
+	fileHandle_t f;
+	int len, i;
+	char *token;
+
+	// cine subtitle filename
+	Q_strncpyz( name, cinTable[handle].fileName, sizeof(name) );
+	char *dot = strrchr( name, '.' );
+    if ( dot ) {
+        *dot = '\0';
+    }
+	Com_sprintf( name, sizeof(name), "%s.sub", name );
+
+	// read file content
+	len = FS_FOpenFileByMode(name, &f, FS_READ);
+	if (len <= 0 && com_developer->integer) {
+		Com_Printf(S_COLOR_YELLOW "cine subtitle file \"%s\" not found or unreadable\n", name);
+		return;
+	}
+	if (len > MAX_BUFFER) {
+		Com_Printf(S_COLOR_YELLOW "\"%s\" is too big, make it smaller (max = %i bytes)\n", name, MAX_BUFFER);
+	}
+
+	FS_Read(buffer, len, f);
+	buffer[len] = 0;
+	FS_FCloseFile(f);
+
+	// parse the lines
+	text = buffer;
+	token = COM_ParseExt(&text, qtrue);
+	if (token[0] != '{') {
+		Com_Printf("^1WARNING: expecting '{', found '%s' instead in cine subtitle file \"video/%s\"\n", token, name);
+		return;
+	}
+
+	memset( cinTable[handle].subtitles, 0, sizeof(cinTable[handle].subtitles) );
+
+	i = 0;
+	while ( cinTable[handle].subtitleCount < MAX_SUBTITLES) {
+		token = COM_ParseExt(&text, qtrue);
+		if (!token[0]) {
+			Com_Printf("^1WARNING: no concluding '}' in cine subtitle file \"video/%s\"\n", name);
+			break;
+		}
+		// end of shader definition
+		if (token[0] == '}') {
+			break;
+		}
+
+		cinTable[handle].subtitles[i].startTime = atoi(token);
+
+		token = COM_ParseExt(&text, qfalse);
+		cinTable[handle].subtitles[i].endTime = atoi(token);
+
+		token = COM_ParseExt(&text, qfalse);
+		Q_strncpyz( cinTable[handle].subtitles[i].lineText, token, sizeof(cinTable[handle].subtitles[i].lineText) );
+
+		token = COM_ParseExt(&text, qfalse);
+		cinTable[handle].subtitles[i].sizeScale = (float)atof(token);
+
+		token = COM_ParseExt(&text, qfalse);
+		cinTable[handle].subtitles[i].x0 = atoi(token);
+
+		token = COM_ParseExt(&text, qfalse);
+		cinTable[handle].subtitles[i].y0 = atoi(token);
+
+		token = COM_ParseExt(&text, qfalse);
+		cinTable[handle].subtitles[i].width = atoi(token);
+
+		// optional parameters
+		token = COM_ParseExt(&text, qfalse);
+		if ( !token[0] ) {
+			cinTable[handle].subtitles[i].x1 = cinTable[handle].subtitles[i].x0;
+			cinTable[handle].subtitles[i].y1 = cinTable[handle].subtitles[i].y0;
+		} else {
+			cinTable[handle].subtitles[i].x1 = atoi(token);
+			token = COM_ParseExt(&text, qfalse);
+			cinTable[handle].subtitles[i].y1 = token[0] ? atoi(token) : cinTable[handle].subtitles[i].y0;
+		}
+
+		cinTable[handle].subtitleCount++;
+		i++;
+	}
+
+}
+
+/*
+==================
+CIN_DrawCinematicSubtitle
+==================
+*/
+static void CIN_DrawCinematicSubtitle( int handle ) {
+	qboolean isCinPlaying = (CL_handle >= 0 && CL_handle < MAX_VIDEO_HANDLES) ||
+							(CL_levelCinHandle >= 0 && CL_levelCinHandle < MAX_VIDEO_HANDLES);
+	
+	if ( !isCinPlaying ) {
+		return;
+	}
+	
+	if ( handle < 0 || handle >= MAX_VIDEO_HANDLES || cinTable[handle].status == FMV_EOF ) {
+		return;
+	}
+
+	if ( !cinTable[handle].buf ) {
+		return;
+	}
+
+	if ( !cl_drawCineSubtitles->value ) {
+		return;
+	}
+
+	// 
+	subtitle_t *subs = cinTable[handle].subtitles;
+	float color[4], backColor[4];
+	color[0] = color[1] = color[2] = color[3] = 1.0;
+	backColor[0] = backColor[1] = backColor[2] = 0;
+	backColor[3] = 1.0;
+
+	int time = CIN_GetCurrentPlayingTime(handle);
+	if ( time <= 0 ) return;
+
+	float x, y, t;
+	for ( int i = 0; i < cinTable[handle].subtitleCount; i++ ) {
+		if ( !subs[i].lineText[0] ) {
+			continue;
+		}
+
+		if ( subs[i].startTime < subs[i].endTime && time >= subs[i].startTime && time <= subs[i].endTime) {
+			if ( subs[i].x1 != subs[i].x0 || subs[i].y1 != subs[i].y0 ) {
+				// if a smoother move effect is needed
+				// then CIN_GetCurrentPlayingTime needs to be modified to get a more accurate timestamp
+				t = (float)(time - subs[i].startTime) / (float)(subs[i].endTime - subs[i].startTime);
+				x = (float)subs[i].x0 + (float)(subs[i].x1 - subs[i].x0) * t;
+				y = (float)subs[i].y0 + (float)(subs[i].y1 - subs[i].y0) * t;
+			} else {
+				x = subs[i].x0;
+				y = subs[i].y0;
+			}
+
+			SCR_Text_AutoWrapped_Paint( x, y, subs[i].sizeScale, subs[i].lineText,
+										subs[i].width, color, TEXT_ALIGN_CENTER );
+		}
+	}
+
 }

--- a/code/client/cl_cin.c
+++ b/code/client/cl_cin.c
@@ -102,7 +102,6 @@ typedef struct {
 	int x1, y1;
 } subtitle_t;
 
-extern cvar_t *cl_drawCineSubtitles;
 static int CIN_GetCurrentPlayingTime( int handle );
 static void CIN_LoadCinematicSubtitle( int handle );
 static void CIN_DrawCinematicSubtitle( int handle );

--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -167,6 +167,8 @@ cvar_t  *cl_useKeyLean;
 
 cvar_t	*cl_rate;
 
+cvar_t	*cl_drawCineSubtitles;
+
 clientActive_t cl;
 clientConnection_t clc;
 clientStatic_t cls;
@@ -3874,6 +3876,7 @@ void CL_Init( void ) {
 	// NERVE - SMF - localization
 	cl_language = Cvar_Get( "cl_language", "0", CVAR_ARCHIVE );
 	cl_debugTranslation = Cvar_Get( "cl_debugTranslation", "0", 0 );
+	cl_drawCineSubtitles = Cvar_Get( "cl_drawCineSubtitles", "0", CVAR_ARCHIVE );
 	// -NERVE - SMF
 
 	//

--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -3322,6 +3322,7 @@ void CL_InitRenderer( void ) {
 
 	// load character sets
 	cls.charSetShader = re.RegisterShader( "gfx/2d/bigchars" );
+	cls.subtitleCharSetShader = re.RegisterShader( "gfx/2d/subchars" );
 	cls.whiteShader = re.RegisterShader( "white" );
 	cls.consoleShader = re.RegisterShader( "console" );
 	cls.consoleShader2 = re.RegisterShader( "console2" );

--- a/code/client/cl_scrn.c
+++ b/code/client/cl_scrn.c
@@ -328,6 +328,89 @@ int SCR_GetBigStringWidth( const char *str ) {
 	return SCR_Strlen( str ) * BIGCHAR_WIDTH;
 }
 
+/*
+==================
+SCR_Text_AutoWrapped_Paint
+==================
+*/
+void SCR_Text_AutoWrapped_Paint( float x, float y, float scale, const char *text, float maxLineWidth, vec4_t color, int alignType) {
+	const char *p, *textPtr, *newLinePtr;
+	char buff[1024];
+	int len, textWidth, newLine, newLineWidth;
+	float x2, y2, maxLineHeight;
+	float size;
+	vec4_t backColor;
+
+	newLinePtr = NULL;
+	if ( !text || !text[0] ) {
+		return;
+	} else {
+		textPtr = text;
+	}
+
+	if ( !color ) {
+		return;
+	}
+
+	re.SetColor( color );
+
+	backColor[0] = backColor[1] = backColor[2] = 0;
+	backColor[3] = 1.0;
+
+	size = BIGCHAR_HEIGHT * scale;
+	maxLineHeight = BIGCHAR_HEIGHT * scale;
+	textWidth = 0;
+
+	x2 = x;
+	y2 = y;
+	len = 0;
+	buff[0] = '\0';
+	newLine = 0;
+	newLineWidth = 0;
+	p = textPtr;
+	while ( p ) {
+		if ( *p == ' ' || *p == '\t' || *p == '\n' || *p == '\0' ) {
+			newLine = len;
+			newLinePtr = p + 1;
+			newLineWidth = textWidth;
+		}
+
+		textWidth = SCR_GetBigStringWidth(buff) * scale;
+		if ( ( newLine && textWidth > maxLineWidth ) || *p == '\n' || *p == '\0' ) {
+			if ( len ) {
+				if ( alignType == TEXT_ALIGN_LEFT ) {
+					x2 = x;
+				} else if ( alignType == TEXT_ALIGN_RIGHT ) {
+					x2 = x + maxLineWidth - newLineWidth;
+				} else if ( alignType == TEXT_ALIGN_CENTER ) {
+					x2 = x + (maxLineWidth - newLineWidth) * 0.5;
+				}
+				
+				buff[newLine] = '\0';
+				SCR_DrawStringExt( x2, y2, size, buff, color, qfalse, qfalse );
+			}
+
+			if ( *p == '\0' ) {
+				break;
+			}
+
+			y2 += maxLineHeight + 3.0f;
+			p = newLinePtr;
+			len = 0;
+			newLine = 0;
+			newLineWidth = 0;
+			continue;
+		}
+		buff[len++] = *p++;
+
+		if ( buff[len-1] == 13 ) {
+			buff[len-1] = ' ';
+		}
+
+		buff[len] = '\0';
+	}
+}
+
 
 //===============================================================================
 

--- a/code/client/cl_scrn.c
+++ b/code/client/cl_scrn.c
@@ -160,6 +160,40 @@ static void SCR_DrawChar( int x, int y, float size, int ch ) {
 					   cls.charSetShader );
 }
 
+static void SCR_DrawCharExt( int x, int y, float size, int ch, int font ) {
+	int row, col;
+	float frow, fcol;
+	float ax, ay, aw, ah;
+
+	ch &= 255;
+
+	if ( ch == ' ' ) {
+		return;
+	}
+
+	if ( y < -size ) {
+		return;
+	}
+
+	ax = x;
+	ay = y;
+	aw = size;
+	ah = size;
+	SCR_AdjustFrom640( &ax, &ay, &aw, &ah );
+
+	row = ch >> 4;
+	col = ch & 15;
+
+	frow = row * 0.0625;
+	fcol = col * 0.0625;
+	size = 0.0625;
+
+	re.DrawStretchPic( ax, ay, aw, ah,
+					   fcol, frow,
+					   fcol + size, frow + size,
+					   font );
+}
+
 /*
 ** SCR_DrawSmallChar
 ** small chars are drawn at native screen resolution
@@ -243,6 +277,50 @@ void SCR_DrawStringExt( int x, int y, float size, const char *string, float *set
 			}
 		}
 		SCR_DrawChar( xx, y, size, *s );
+		xx += size;
+		s++;
+	}
+	re.SetColor( NULL );
+}
+
+void SCR_DrawStringExt2( int x, int y, float size, const char *string, float *setColor, qboolean forceColor,
+		qboolean noColorEscape, int font ) {
+	vec4_t color;
+	const char  *s;
+	int xx;
+
+	// draw the drop shadow
+	color[0] = color[1] = color[2] = 0;
+	color[3] = setColor[3];
+	re.SetColor( color );
+	s = string;
+	xx = x;
+	while ( *s ) {
+		if ( !noColorEscape && Q_IsColorString( s ) ) {
+			s += 2;
+			continue;
+		}
+		SCR_DrawCharExt( xx + 2, y + 2, size, *s, font );
+		xx += size;
+		s++;
+	}
+
+	s = string;
+	xx = x;
+	re.SetColor( setColor );
+	while ( *s ) {
+		if ( Q_IsColorString( s ) ) {
+			if ( !forceColor ) {
+				memcpy( color, g_color_table[ColorIndex( *( s + 1 ) )], sizeof( color ) );
+				color[3] = setColor[3];
+				re.SetColor( color );
+			}
+			if ( !noColorEscape ) {
+				s += 2;
+				continue;
+			}
+		}
+		SCR_DrawCharExt( xx, y, size, *s, font );
 		xx += size;
 		s++;
 	}
@@ -333,13 +411,19 @@ int SCR_GetBigStringWidth( const char *str ) {
 SCR_Text_AutoWrapped_Paint
 ==================
 */
-void SCR_Text_AutoWrapped_Paint( float x, float y, float scale, const char *text, float maxLineWidth, vec4_t color, int alignType) {
+void SCR_Text_AutoWrapped_Paint( float x, float y, float scale, const char *text, float maxLineWidth, vec4_t color,
+								int alignType, int font ) {
 	const char *p, *textPtr, *newLinePtr;
 	char buff[1024];
 	int len, textWidth, newLine, newLineWidth;
 	float x2, y2, maxLineHeight;
 	float size;
 	vec4_t backColor;
+
+	if ( !font ) {
+		Com_DPrintf(S_COLOR_YELLOW "SCR_Text_AutoWrapped_Paint: switch to the default charSetShader\n");
+		font = cls.charSetShader;
+	}
 
 	newLinePtr = NULL;
 	if ( !text || !text[0] ) {
@@ -387,7 +471,7 @@ void SCR_Text_AutoWrapped_Paint( float x, float y, float scale, const char *text
 				}
 				
 				buff[newLine] = '\0';
-				SCR_DrawStringExt( x2, y2, size, buff, color, qfalse, qfalse );
+				SCR_DrawStringExt2( x2, y2, size, buff, color, qfalse, qfalse, font );
 			}
 
 			if ( *p == '\0' ) {

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -60,6 +60,11 @@ If you have questions concerning this license or the applicable additional terms
 #define LIMBOCHAT_WIDTH		140     // NERVE - SMF
 #define LIMBOCHAT_HEIGHT	7       // NERVE - SMF
 
+// cl_scrn
+#define TEXT_ALIGN_LEFT     0       // left alignment
+#define TEXT_ALIGN_CENTER   1       // center alignment
+#define TEXT_ALIGN_RIGHT    2       // right alignment
+
 // snapshots are a view of the server at a given time
 typedef struct {
 	qboolean valid;                 // cleared if delta parsing was invalid
@@ -703,6 +708,9 @@ void	SCR_DrawBigString( int x, int y, const char *s, float alpha, qboolean noCol
 void	SCR_DrawBigStringColor( int x, int y, const char *s, vec4_t color, qboolean noColorEscape );	// ignores embedded color control characters
 void	SCR_DrawSmallStringExt( int x, int y, const char *string, float *setColor, qboolean forceColor, qboolean noColorEscape );
 void    SCR_DrawSmallChar( int x, int y, int ch );
+
+void    SCR_DrawStringExt( int x, int y, float size, const char *string, float *setColor, qboolean forceColor, qboolean noColorEscape );
+void    SCR_Text_AutoWrapped_Paint( float x, float y, float scale, const char *text, float maxLineWidth, vec4_t color, int alignType);
 
 
 //

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -388,6 +388,9 @@ typedef struct {
 	qhandle_t whiteShader;
 	qhandle_t consoleShader;
 	qhandle_t consoleShader2;   //----(SA)	added
+
+	// cine subtitle
+	qhandle_t subtitleCharSetShader;
 } clientStatic_t;
 
 extern clientStatic_t cls;
@@ -711,7 +714,8 @@ void	SCR_DrawSmallStringExt( int x, int y, const char *string, float *setColor, 
 void    SCR_DrawSmallChar( int x, int y, int ch );
 
 void    SCR_DrawStringExt( int x, int y, float size, const char *string, float *setColor, qboolean forceColor, qboolean noColorEscape );
-void    SCR_Text_AutoWrapped_Paint( float x, float y, float scale, const char *text, float maxLineWidth, vec4_t color, int alignType);
+void    SCR_DrawStringExt2( int x, int y, float size, const char *string, float *setColor, qboolean forceColor, qboolean noColorEscape, int font );
+void    SCR_Text_AutoWrapped_Paint( float x, float y, float scale, const char *text, float maxLineWidth, vec4_t color, int alignType, int font );
 
 
 //

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -529,6 +529,7 @@ extern cvar_t  *cl_waitForFire;
 
 // NERVE - SMF - localization
 extern cvar_t  *cl_language;
+extern cvar_t  *cl_drawCineSubtitles;
 // -NERVE - SMF
 
 //=================================================


### PR DESCRIPTION
Support display subtitles when playing cutscene cine.

Just create a sub extension text file with the same name as the video and put it in the same directory. Then open console:
`seta cl_drawcinesubtitles 1`
It may provide convenience for various languages localization without edit the videos.

If subtitle text need custom font, modify "gfx/2d/subchars.tga":
[subchars.zip](https://github.com/user-attachments/files/28193005/subchars.zip)

syntax:
{
startTime endTime text sizeScale x0 y0 width [x1 y1]
...
}


an example SUB file `wolfintro.sub` for wolfintro.webm or wolfintro.roq:
```
// startTime endTime text sizeScale x0 y0 width [x1 y1]
//     x0 y0: The initial position of subtitle.
//     x1 y1: Optional parameter. The end position of subtitle, if not specify, subtitle is fixed position.
// Position scaling based on 640x480
// The cinematic subtitles text display rectangle position is just similar with 'rect' in ui menu script file.
/*
 ---------------------------
|                           |
| x0         x0 + width     |
|  \            \           |
|  *------------*           |  <- y0
|  |    text    |           |
|  |    text    |           |
|  |    ...     |           |
|                           |
 ---------------------------
            game window
*/

{
70000 74500  "Heinrich, your reign of terror must end!"  0.6  95  430  450

75000 80500  "You fool, you know that I can not be destroyed!"  0.6  95  430  450

105000 108500  "A prison man..."  0.6  95  430  450

125000 131000  "May the faith hold off the coming storm..."  0.6  95  430  450

153000 162000  "Return to castle Wolfenstein Immediately, note Himmler, we found 'him'."  0.6  95  430  450
}
```


video effect:

https://github.com/user-attachments/assets/6e68a378-9a4a-4627-9d77-747fe084ed3a

https://github.com/user-attachments/assets/c6d03b90-815d-48d3-a2d8-847fe5bd831a
