### PR TITLE
fix(qcommon,game): cast LHS of left shifts to unsigned to avoid signed-int UB

### DIFF
--- a/code/game/g_misc.c
+++ b/code/game/g_misc.c
@@ -1395,7 +1395,7 @@ void SP_dlight( gentity_t *ent ) {
 	i = (int)( ent->dl_stylestring[offset] ) - (int)'a';
 	i = i * ( 1000.0f / 24.0f );
 
-	ent->s.constantLight =  (int)ent->dl_color[0] | ( (int)ent->dl_color[1] << 8 ) | ( (int)ent->dl_color[2] << 16 ) | ( i / 4 << 24 );
+	ent->s.constantLight =  (int)ent->dl_color[0] | ( (int)ent->dl_color[1] << 8 ) | ( (int)ent->dl_color[2] << 16 ) | ( (unsigned)( i / 4 ) << 24 );
 
 	ent->use = use_dlight;
 

--- a/code/qcommon/msg.c
+++ b/code/qcommon/msg.c
@@ -1501,13 +1501,13 @@ void MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct p
 	statsbits = 0;
 	for ( i = 0 ; i < MAX_STATS ; i++ ) {
 		if ( to->stats[i] != from->stats[i] ) {
-			statsbits |= 1 << i;
+			statsbits |= 1u << i;
 		}
 	}
 	persistantbits = 0;
 	for ( i = 0 ; i < MAX_PERSISTANT ; i++ ) {
 		if ( to->persistant[i] != from->persistant[i] ) {
-			persistantbits |= 1 << i;
+			persistantbits |= 1u << i;
 		}
 	}
 	holdablebits[0] = 0;
@@ -1518,20 +1518,20 @@ void MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct p
             if ( idx >= MAX_HOLDABLE ) break;
 
             if ( to->holdable[idx] != from->holdable[idx] ) {
-                holdablebits[j] |= 1 << i;
+                holdablebits[j] |= 1u << i;
             }
         }
     }
 	powerupbits = 0;
 	for (i = 0; i < MAX_POWERUPS; i++) {
 		if (to->powerups[i] != from->powerups[i]) {
-			powerupbits |= 1 << i;
+			powerupbits |= 1u << i;
 		}
 	}
 	perksbits = 0;
 	for (i = 0; i < MAX_PERKS; i++) {
 		if (to->perks[i] != from->perks[i]) {
-			perksbits |= 1 << i;
+			perksbits |= 1u << i;
 		}
 	}
 
@@ -1544,7 +1544,7 @@ void MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct p
 			MSG_WriteBits( msg, 1, 1 ); // changed
 			MSG_WriteBits( msg, statsbits, MAX_STATS );
 			for ( i = 0 ; i < MAX_STATS ; i++ )
-				if ( statsbits & ( 1 << i ) ) {
+				if ( statsbits & ( 1u << i ) ) {
 					// RF, changed to long to allow more flexibility
 //					MSG_WriteLong (msg, to->stats[i]);
 					MSG_WriteShort( msg, to->stats[i] );  //----(SA)	back to short since weapon bits are handled elsewhere now
@@ -1558,7 +1558,7 @@ void MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct p
 			MSG_WriteBits( msg, 1, 1 ); // changed
 			MSG_WriteBits( msg, persistantbits, MAX_PERSISTANT );
 			for ( i = 0 ; i < MAX_PERSISTANT ; i++ )
-				if ( persistantbits & ( 1 << i ) ) {
+				if ( persistantbits & ( 1u << i ) ) {
 					MSG_WriteLong( msg, to->persistant[i] );
 				}
 		} else {
@@ -1576,7 +1576,7 @@ void MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct p
                     MSG_WriteShort( msg, holdablebits[j] );
 
                     for ( i = 0; i < 16; i++ ) {
-                        if ( holdablebits[j] & ( 1 << i ) ) {
+                        if ( holdablebits[j] & ( 1u << i ) ) {
                             int idx = i + j * 16;
                             MSG_WriteShort( msg, to->holdable[idx] );
                         }
@@ -1593,7 +1593,7 @@ void MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct p
 			MSG_WriteBits( msg, 1, 1 ); // changed
 			MSG_WriteBits( msg, powerupbits, MAX_POWERUPS );
 			for ( i = 0 ; i < MAX_POWERUPS ; i++ )
-				if ( powerupbits & ( 1 << i ) ) {
+				if ( powerupbits & ( 1u << i ) ) {
 					MSG_WriteLong( msg, to->powerups[i] );
 				}
 		} else {
@@ -1604,7 +1604,7 @@ void MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct p
 			MSG_WriteBits( msg, 1, 1 ); // changed
 			MSG_WriteBits( msg, perksbits, MAX_PERKS );
 			for ( i = 0 ; i < MAX_PERKS ; i++ )
-				if ( perksbits & ( 1 << i ) ) {
+				if ( perksbits & ( 1u << i ) ) {
 					MSG_WriteLong( msg, to->perks[i] );
 				}
 		} else {
@@ -1629,13 +1629,13 @@ void MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct p
 		// ammo
 		for ( i = 0 ; i < 32 ; i++ ) {
 			if ( to->ammo[i] != from->ammo[i] ) {
-				ammobits |= 1 << i;
+				ammobits |= 1u << i;
 			}
 		}
 		// ammoclip (just add these changes to the ammo changes. if either changes, we should send both, since they are likely to both change at once anyway)
 		for ( i = 0 ; i < 32 ; i++ ) {
 			if ( to->ammoclip[i] != from->ammoclip[i] ) {
-				ammobits |= 1 << i;
+				ammobits |= 1u << i;
 			}
 		}
 
@@ -1644,7 +1644,7 @@ void MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct p
 
 			// send each changed item
 			for ( i = 0 ; i < 32 ; i++ ) {
-				if ( ammobits & ( 1 << i ) ) {
+				if ( ammobits & ( 1u << i ) ) {
 					ammo_ofs = to->ammo[i] - from->ammo[i];
 					clip_ofs = to->ammoclip[i] - from->ammoclip[i];
 
@@ -1707,7 +1707,7 @@ void MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct p
 		ammobits[j] = 0;
 		for ( i = 0 ; i < 16 ; i++ ) {
 			if ( to->ammo[i + ( j * 16 )] != from->ammo[i + ( j * 16 )] ) {
-				ammobits[j] |= 1 << i;
+				ammobits[j] |= 1u << i;
 			}
 		}
 	}
@@ -1721,7 +1721,7 @@ void MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct p
 				MSG_WriteBits( msg, 1, 1 ); // changed
 				MSG_WriteShort( msg, ammobits[j] );
 				for ( i = 0 ; i < 16 ; i++ )
-					if ( ammobits[j] & ( 1 << i ) ) {
+					if ( ammobits[j] & ( 1u << i ) ) {
 						MSG_WriteShort( msg, to->ammo[i + ( j * 16 )] );
 					}
 			} else {
@@ -1737,14 +1737,14 @@ void MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct p
 		clipbits = 0;
 		for ( i = 0 ; i < 16 ; i++ ) {
 			if ( to->ammoclip[i + ( j * 16 )] != from->ammoclip[i + ( j * 16 )] ) {
-				clipbits |= 1 << i;
+				clipbits |= 1u << i;
 			}
 		}
 		if ( clipbits ) {
 			MSG_WriteBits( msg, 1, 1 ); // changed
 			MSG_WriteShort( msg, clipbits );
 			for ( i = 0 ; i < 16 ; i++ )
-				if ( clipbits & ( 1 << i ) ) {
+				if ( clipbits & ( 1u << i ) ) {
 					MSG_WriteShort( msg, to->ammoclip[i + ( j * 16 )] );
 				}
 		} else {
@@ -1762,7 +1762,7 @@ void MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct p
 			int index = i + j * 16;
 			if (to->weaponUpgraded[index] != from->weaponUpgraded[index])
 			{
-				upgradedBits[j] |= 1 << i;
+				upgradedBits[j] |= 1u << i;
 			}
 		}
 	}
@@ -1780,7 +1780,7 @@ void MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct p
 
 				for (int i = 0; i < 16; i++)
 				{
-					if (upgradedBits[j] & (1 << i))
+					if (upgradedBits[j] & (1u << i))
 					{
 						int index = i + j * 16;
 						MSG_WriteShort(msg, to->weaponUpgraded[index]);
@@ -1901,7 +1901,7 @@ void MSG_ReadDeltaPlayerstate( msg_t *msg, playerState_t *from, playerState_t *t
 			LOG( "PS_STATS" );
 			bits = MSG_ReadBits (msg, MAX_STATS);
 			for ( i = 0 ; i < MAX_STATS ; i++ ) {
-				if ( bits & ( 1 << i ) ) {
+				if ( bits & ( 1u << i ) ) {
 					// RF, changed to long to allow more flexibility
 //					to->stats[i] = MSG_ReadLong(msg);
 					to->stats[i] = MSG_ReadShort( msg );  //----(SA)	back to short since weapon bits are handled elsewhere now
@@ -1915,7 +1915,7 @@ void MSG_ReadDeltaPlayerstate( msg_t *msg, playerState_t *from, playerState_t *t
 			LOG( "PS_PERSISTANT" );
 			bits = MSG_ReadBits (msg, MAX_PERSISTANT);
 			for ( i = 0 ; i < MAX_PERSISTANT ; i++ ) {
-				if ( bits & ( 1 << i ) ) {
+				if ( bits & ( 1u << i ) ) {
 					to->persistant[i] = MSG_ReadLong( msg );
 				}
 			}
@@ -1930,7 +1930,7 @@ void MSG_ReadDeltaPlayerstate( msg_t *msg, playerState_t *from, playerState_t *t
                     bits = MSG_ReadShort( msg );
 
                     for ( i = 0; i < 16; i++ ) {
-                        if ( bits & ( 1 << i ) ) {
+                        if ( bits & ( 1u << i ) ) {
                             int idx = i + j * 16;
                             if ( idx < MAX_HOLDABLE ) {
                                 to->holdable[idx] = MSG_ReadShort( msg );
@@ -1949,7 +1949,7 @@ void MSG_ReadDeltaPlayerstate( msg_t *msg, playerState_t *from, playerState_t *t
 			LOG( "PS_POWERUPS" );
 			bits = MSG_ReadBits (msg, MAX_POWERUPS);
 			for ( i = 0 ; i < MAX_POWERUPS ; i++ ) {
-				if ( bits & ( 1 << i ) ) {
+				if ( bits & ( 1u << i ) ) {
 					to->powerups[i] = MSG_ReadLong( msg );
 				}
 			}
@@ -1960,7 +1960,7 @@ void MSG_ReadDeltaPlayerstate( msg_t *msg, playerState_t *from, playerState_t *t
 			LOG( "PS_PERKS" );
 			bits = MSG_ReadBits (msg, MAX_PERKS);
 			for ( i = 0 ; i < MAX_PERKS ; i++ ) {
-				if ( bits & ( 1 << i ) ) {
+				if ( bits & ( 1u << i ) ) {
 					to->perks[i] = MSG_ReadLong( msg );
 				}
 			}
@@ -2001,7 +2001,7 @@ void MSG_ReadDeltaPlayerstate( msg_t *msg, playerState_t *from, playerState_t *t
 				LOG( "PS_AMMO" );
 				bits = MSG_ReadShort( msg );
 				for ( i = 0 ; i < 16 ; i++ ) {
-					if ( bits & ( 1 << i ) ) {
+					if ( bits & ( 1u << i ) ) {
 						to->ammo[i + ( j * 16 )] = MSG_ReadShort( msg );
 					}
 				}
@@ -2015,7 +2015,7 @@ void MSG_ReadDeltaPlayerstate( msg_t *msg, playerState_t *from, playerState_t *t
 			LOG( "PS_AMMOCLIP" );
 			bits = MSG_ReadShort( msg );
 			for ( i = 0 ; i < 16 ; i++ ) {
-				if ( bits & ( 1 << i ) ) {
+				if ( bits & ( 1u << i ) ) {
 					to->ammoclip[i + ( j * 16 )] = MSG_ReadShort( msg );
 				}
 			}
@@ -2032,7 +2032,7 @@ void MSG_ReadDeltaPlayerstate( msg_t *msg, playerState_t *from, playerState_t *t
 
 				for (int i = 0; i < 16; i++)
 				{
-					if (bits & (1 << i))
+					if (bits & (1u << i))
 					{
 						int index = i + j * 16;
 						to->weaponUpgraded[index] = MSG_ReadShort(msg);

--- a/code/qcommon/q_shared.c
+++ b/code/qcommon/q_shared.c
@@ -194,7 +194,7 @@ qboolean COM_BitCheck( const int array[], int bitNum ) {
 		bitNum -= 32;
 	}
 
-	return ( ( array[i] & ( 1 << bitNum ) ) != 0 );  // (SA) heh, whoops. :)
+	return ( ( array[i] & ( 1u << bitNum ) ) != 0 );  // (SA) heh, whoops. :)
 }
 
 /*
@@ -213,7 +213,7 @@ void COM_BitSet( int array[], int bitNum ) {
 		bitNum -= 32;
 	}
 
-	array[i] |= ( 1 << bitNum );
+	array[i] |= ( 1u << bitNum );
 }
 
 /*
@@ -232,7 +232,7 @@ void COM_BitClear( int array[], int bitNum ) {
 		bitNum -= 32;
 	}
 
-	array[i] &= ~( 1 << bitNum );
+	array[i] &= ~( 1u << bitNum );
 }
 //============================================================================
 


### PR DESCRIPTION
## Summary
Fixes 5 instances of signed-integer left-shift UB caught by UBSAN on a `-fsanitize=undefined` build of the macOS arm64 port. All sites use bit masks where the integer is treated as a bit pattern, so casting the LHS to `unsigned` is bit-identical on 2's-complement (i.e., everywhere) but standards-clean.

- `code/qcommon/q_shared.c` COM_BitCheck / COM_BitSet / COM_BitClear — `1 << bitNum` where `bitNum` may reach 31.
- `code/qcommon/msg.c` MSG_Write/ReadDeltaPlayerstate — 27 sites of `1 << i` where `i` iterates over `MAX_STATS` / `MAX_PERSISTANT` / `MAX_POWERUPS` / `MAX_PERKS` / `MAX_WEAPONS` / `MAX_AMMO` / etc., which can reach 31. Wire format is bit-identical (verified by inspection and by the UBSAN before/after in the test plan).
- `code/game/g_misc.c` SP_dlight color pack — `( i / 4 ) << 24` where `i/4` routinely exceeds 127.

All three are vanilla-Q3-lineage code; the same lines exist in the id Software 2010 RTCW SP source drop, so this PR is also a candidate to forward to ioquake3 / RTCW MP downstream.

## Test plan
- [x] Builds clean on macOS arm64 (Apple clang 21)
- [x] UBSAN-only build before/after on the same scripted scenario: 5 `left shift of N by M places cannot be represented in type 'int'` hits → **0**
- [x] Game launches and plays mission 1 cleanly through a scripted ~90s autorun (`map escape1` + `give all` + `s_useOpenAL 0` + `snd_restart` + `find` / `cmdlist` / `imagelist` / `savegame` / `disconnect` / `quit`); no functional regression observed
- [ ] Multiplayer wire-format unaffected — please confirm with your usual MP smoke test (the `MSG_*DeltaPlayerstate` changes touch the snapshot serialisation path)

Found during a broader UBSAN triage of the macOS arm64 build alongside the other macOS PRs (#216, #217, #218). A companion PR follows for a separate UBSAN finding in cgame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)