### PR TITLE
Fix out-of-bounds s_entityTalkAmplitude write crash

### DIFF
--- a/code/client/snd_openal.c
+++ b/code/client/snd_openal.c
@@ -1722,7 +1722,7 @@ static void S_AL_MainStartSound( vec3_t origin, int entnum, int entchannel, sfxH
   srcHandle_t src;
   src_t *curSource;
 
-  if ( entnum >= 0 && entnum < MAX_GENTITIES ) 
+  if ( entnum >= 0 && entnum < MAX_CLIENTS ) 
   {
     s_entityTalkAmplitude[entnum] = 0;
   }
@@ -1772,7 +1772,7 @@ static void S_AL_MainStartSound( vec3_t origin, int entnum, int entchannel, sfxH
 
   curSource = &srcList[src];
 
-  if ( (entnum < MAX_CLIENTS) && (entchannel == CHAN_VOICE) )
+  if ( (entnum >= 0 && entnum < MAX_CLIENTS) && (entchannel == CHAN_VOICE) )
   {
     if(offset_ext && knownSfx[sfx].voice){
       s_entityTalkAmplitude[entnum] = S_AL_VoiceAmplitude(sfx, VOICE_AHEAD);
@@ -2176,11 +2176,16 @@ void S_AL_SrcUpdate( void )
     // See if it needs to be moved
     if(curSource->isTracking && !state)
     {
-      qalSourcefv(curSource->alSource, AL_POSITION, entityList[entityNum].origin);
-      S_AL_ScaleGain(curSource, entityList[entityNum].origin);
+      // Guard against a stale/invalid entity index (can happen during
+      // scripted scenes) which would dereference a wild pointer.
+      if(entityNum >= 0 && entityNum < MAX_GENTITIES)
+      {
+        qalSourcefv(curSource->alSource, AL_POSITION, entityList[entityNum].origin);
+        S_AL_ScaleGain(curSource, entityList[entityNum].origin);
+      }
     }
 
-    if ( ( entityNum < MAX_CLIENTS) && (entityChannel == CHAN_VOICE ))
+    if ( ( entityNum >= 0 && entityNum < MAX_CLIENTS) && (entityChannel == CHAN_VOICE ))
     {
       if(offset_ext && knownSfx[curSource->sfx].voice ){
         qalGetSourcef(curSource->alSource,AL_SEC_OFFSET,&offset);


### PR DESCRIPTION
S_AL_MainStartSound checked the entity index against MAX_GENTITIES before writing s_entityTalkAmplitude[entnum], but the array is only MAX_CLIENTS in size. Non-client entities (like the SS soldiers in the escape1 electrocution scene) have indices above MAX_CLIENTS, so the write overran the array and corrupted the adjacent s_musicVolume cvar pointer, crashing the next frame in S_AL_MusicUpdate.

This fixes the bound to MAX_CLIENTS, adds a lower >= 0 guard to the CHAN_VOICE blocks, and guards the isTracking entityList access against stale indices.

Tested on macOS (Apple Silicon): the escape1 scene no longer crashes.