### PR TITLE
Enable native macOS (Apple Silicon) builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -511,6 +511,12 @@ ifeq ($(PLATFORM),darwin)
   RENDERER_LIBS=
   OPTIMIZEVM = -O3
 
+  # FFmpeg (Homebrew) for cinematic playback in cl_cin.c
+  FFMPEG_CFLAGS := $(shell PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig pkg-config --cflags libavcodec libavformat libavutil libswscale libswresample)
+  FFMPEG_LIBS   := $(shell PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig pkg-config --libs   libavcodec libavformat libavutil libswscale libswresample)
+  CFLAGS  += $(FFMPEG_CFLAGS)
+  CLIENT_LIBS += $(FFMPEG_LIBS)
+
   # Default minimum Mac OS X version
   ifeq ($(MACOSX_VERSION_MIN),)
     MACOSX_VERSION_MIN=10.5

--- a/code/freetype-2.9/src/gzip/ftzconf.h
+++ b/code/freetype-2.9/src/gzip/ftzconf.h
@@ -215,7 +215,7 @@
 #   define FAR
 #endif
 
-#if !defined(MACOS) && !defined(TARGET_OS_MAC)
+#if (!defined(MACOS) && !defined(TARGET_OS_MAC)) || defined(__APPLE__)
 typedef unsigned char  Byte;  /* 8 bits */
 #endif
 typedef unsigned int   uInt;  /* 16 bits or more */

--- a/code/zlib-1.2.11/zutil.h
+++ b/code/zlib-1.2.11/zutil.h
@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  endif
 #endif
 
-#if defined(MACOS) || defined(TARGET_OS_MAC)
+#if (defined(MACOS) || defined(TARGET_OS_MAC)) && !defined(__APPLE__)
 #  define OS_CODE  7
 #  ifndef Z_SOLO
 #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os


### PR DESCRIPTION
Three small changes let the tree build on a modern macOS SDK / arm64:

- Makefile: wire Homebrew FFmpeg into the darwin client build (cl_cin.c uses FFmpeg unconditionally, but only the linux section added its flags).
- zlib zutil.h: the legacy TARGET_OS_MAC block defined fdopen() to NULL, which breaks the real fdopen() in a modern <stdio.h>; exclude __APPLE__ builds.
- freetype ftzconf.h: the mirror-image guard left Byte undefined on modern macOS; re-enable the typedef for __APPLE__.

Built and ran via ./make-macosx.sh arm64.